### PR TITLE
Allow installing Iteaduino Lite as a package under Arduino IDE 1.6.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Introduction
+This repository allows you to install board support for the [Iteaduino Lite](https://www.itead.cc/wiki/Iteaduino_Lite) board, produced by Itead.
+
+## Installation
+Assuming you have already installed your board's COM port drivers.
+
+1. Install Arduino IDE (Tested with 1.6.12, other versions may work also)
+2. Go to the "File" -> "Preferences" Menu
+3. to go the "Settings" tab, and under the "Additional BoardManager URLs" field, insert the following URL:
+   [https://raw.githubusercontent.com/udif/ITEADSW_Iteaduino-Lite-HSP/master/package/package_iteaduino_lite_index.json](https://raw.githubusercontent.com/udif/ITEADSW_Iteaduino-Lite-HSP/master/package/package_iteaduino_lite_index.json)
+   If there is already another URL, add the URL above, separating it with a comma (,) from the existing URL(s).
+4. Under the "Tools" -> "Board: xxx" menu select the topmost option in the scrolling list of boards - "Board Manager".
+5. Find "Iteaduino Lite" in the board list (You can filter your search) and select it. Install it by pressing the "Install button"
+6. Under the "Tools" menu, select the new "Board: Iteaduino Lite" option.
+7. Select your COM port.
+8. You may use the board now.
+
+Please check the original Readme file in this directory for more specific information on the LGT8F Hardware Support Package (HSP).

--- a/hardware/LGT/LGT8F/platform.txt
+++ b/hardware/LGT/LGT8F/platform.txt
@@ -12,7 +12,7 @@ version=1.5.6
 # --------------------- 
 
 # Default "compiler.path" is correct, change only if you want to overidde the initial value
-#compiler.path={ide.path}/tools/avr/bin/..
+compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
 compiler.c.flags=-c -g -Os -w -ffunction-sections -fdata-sections -MMD
 compiler.c.elf.flags=-Os -Wl,--gc-sections
@@ -44,10 +44,10 @@ recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -m
 recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
-recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} "{build.path}/{archive_file}" "{object_file}"
+recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" -lm
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} -o "{build.path}/{build.project_name}.elf" {object_files} "{archive_file_path}" "-L{build.path}" -lm
 
 ## Create eeprom
 recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.objcopy.eep.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"
@@ -65,8 +65,9 @@ recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 # AVR Uploader/Programmers tools
 # ------------------------------
 
-tools.avrdude.cmd.path={runtime.ide.path}/hardware/tools/avr/bin/avrdude
-tools.avrdude.config.path={runtime.ide.path}/hardware/tools/avr/etc/avrdude.conf
+tools.avrdude.path={runtime.tools.avrdude.path}
+tools.avrdude.cmd.path={path}/bin/avrdude
+tools.avrdude.config.path={path}/etc/avrdude.conf
 tools.avrdude.cmd.path.linux={runtime.ide.path}/hardware/tools/avrdude
 tools.avrdude.config.path.linux={runtime.ide.path}/hardware/tools/avrdude.conf
 

--- a/package/package_iteaduino_lite_index.json
+++ b/package/package_iteaduino_lite_index.json
@@ -8,12 +8,12 @@
         {
           "name": "Iteaduino Lite",
           "architecture": "avr",
-          "version": "0.0.1",
+          "version": "0.9",
           "category": "Contributed",
-          "url": "https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP/releases/download/v0.0.1/iteaduino_lite_board.zip",
+          "url": "https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP/releases/download/v0.9/iteaduino_lite_board.zip",
           "archiveFileName": "iteaduino_lite_board.zip",
-          "checksum": "SHA-256:f6cd5897695fb36deaf10cdf1f430a74f53cdf78bc115dc15baa090f9831a8d4",
-          "size": "126812",
+          "checksum": "SHA-256:fc1c0847ff54df757b5b1d2405ea44e51b3f4458e3889b280676adce00e13053",
+          "size": "126811",
           "boards": [
             {"name": "Iteaduino Lite"}
           ],

--- a/package/package_iteaduino_lite_index.json
+++ b/package/package_iteaduino_lite_index.json
@@ -12,8 +12,8 @@
           "category": "Contributed",
           "url": "https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP/releases/download/v0.0.1/iteaduino_lite_board.zip",
           "archiveFileName": "iteaduino_lite_board.zip",
-          "checksum": "SHA-256:65f4e6ed1bd25ddea1877e961d54a7fcb7022db50dcce165a96b9506635badc1",
-          "size": "123632",
+          "checksum": "SHA-256:f6cd5897695fb36deaf10cdf1f430a74f53cdf78bc115dc15baa090f9831a8d4",
+          "size": "126812",
           "boards": [
             {"name": "Iteaduino Lite"}
           ],

--- a/package/package_iteaduino_lite_index.json
+++ b/package/package_iteaduino_lite_index.json
@@ -8,7 +8,7 @@
         {
           "name": "Iteaduino Lite",
           "architecture": "LGT8F88A",
-          "version": "1.0.0",
+          "version": "0.0.1",
           "category": "Contributed",
           "url": "https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP/releases/download/v0.0.1/iteaduino_lite_board.zip",
           "archiveFileName": "iteaduino_lite_board.zip",

--- a/package/package_iteaduino_lite_index.json
+++ b/package/package_iteaduino_lite_index.json
@@ -7,7 +7,7 @@
       "platforms": [
         {
           "name": "Iteaduino Lite",
-          "architecture": "LGT8F88A",
+          "architecture": "avr",
           "version": "0.0.1",
           "category": "Contributed",
           "url": "https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP/releases/download/v0.0.1/iteaduino_lite_board.zip",

--- a/package/package_iteaduino_lite_index.json
+++ b/package/package_iteaduino_lite_index.json
@@ -1,0 +1,37 @@
+{
+  "packages": [
+    {
+      "name": "iteaduino_lite",
+      "maintainer": "udif",
+      "websiteURL": "https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP",
+      "platforms": [
+        {
+          "name": "Iteaduino Lite",
+          "architecture": "LGT8F88A",
+          "version": "1.0.0",
+          "category": "Contributed",
+          "url": "https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP/releases/download/v0.0.1/iteaduino_lite_board.zip",
+          "archiveFileName": "iteaduino_lite_board.zip",
+          "checksum": "SHA-256:2acf8089a8840cd8c5cb521c4f3f7e552bdeaa355d65be9f8fc0b46198da1a9b",
+          "size": "4450",
+          "boards": [
+            {"name": "Explorer"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
+        }
+      ],
+      "tools":[]
+    }
+  ]
+}

--- a/package/package_iteaduino_lite_index.json
+++ b/package/package_iteaduino_lite_index.json
@@ -12,10 +12,10 @@
           "category": "Contributed",
           "url": "https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP/releases/download/v0.0.1/iteaduino_lite_board.zip",
           "archiveFileName": "iteaduino_lite_board.zip",
-          "checksum": "SHA-256:2acf8089a8840cd8c5cb521c4f3f7e552bdeaa355d65be9f8fc0b46198da1a9b",
-          "size": "4450",
+          "checksum": "SHA-256:65f4e6ed1bd25ddea1877e961d54a7fcb7022db50dcce165a96b9506635badc1",
+          "size": "123632",
           "boards": [
-            {"name": "Explorer"}
+            {"name": "Iteaduino Lite"}
           ],
           "toolsDependencies": [
             {


### PR DESCRIPTION
Just make sure to copy my v0.9 release file:
https://github.com/udif/ITEADSW_Iteaduino-Lite-HSP/releases/tag/v0.9
And fix the paths in the JSON file.
(SHA256 and size would stay the same).
